### PR TITLE
User .joke_by_id method

### DIFF
--- a/lib/user.rb
+++ b/lib/user.rb
@@ -13,4 +13,10 @@ class User
   def tell(user, joke)
     user.learn(joke)
   end
+
+  def joke_by_id(id)
+    @jokes.find do |joke|
+      joke.id == id
+    end
+  end
 end

--- a/test/user_test.rb
+++ b/test/user_test.rb
@@ -37,7 +37,7 @@ class UserTest < Minitest::Test
     assert_equal 2, @sal.jokes.length
   end
 
-  def test_user_can_tell_one_joke_to_another_user
+  def test_it_can_tell_one_joke_to_another_user
     @sal.learn(@joke_1)
     @sal.learn(@joke_2)
 
@@ -48,7 +48,7 @@ class UserTest < Minitest::Test
     assert_equal @joke_1, @ali.jokes[0]
   end
 
-  def test_user_can_tell_multiple_jokes_to_another_user
+  def test_it_can_tell_multiple_jokes_to_another_user
     @sal.learn(@joke_1)
     @sal.learn(@joke_2)
 
@@ -61,4 +61,11 @@ class UserTest < Minitest::Test
     assert_equal 2, @ali.jokes.length
   end
 
+  def test_it_can_access_jokes_by_id
+    @ali.learn(@joke_1)
+    @ali.learn(@joke_2)
+
+    assert_equal @joke_1, @ali.joke_by_id(1)
+    assert_equal @joke_2, @ali.joke_by_id(2)
+  end
 end


### PR DESCRIPTION
This `joke_by_id` method will allow a User to find the Jokes they know by ID.
This currently does not have any handling for situations where there might be two jokes with the same ID. This could be resolved by storing these jokes in a Hash. The Hash would remove the first joke with that ID, but it would also ensure there aren't duplicate ID's.
This spec asks that the user.jokes return an empty array.

This is the end of Iteration 3.