### PR TITLE
OpenMic class init and tests

### DIFF
--- a/lib/open_mic.rb
+++ b/lib/open_mic.rb
@@ -1,9 +1,10 @@
 class OpenMic
-  attr_reader :location, :date
+  attr_reader :location, :date, :performers
 
   def initialize(hash)
     @location = hash[:location]
     @date = hash[:date]
+    @performers = []
   end
 
 

--- a/lib/open_mic.rb
+++ b/lib/open_mic.rb
@@ -1,0 +1,10 @@
+class OpenMic
+  attr_reader :location, :date
+
+  def initialize(hash)
+    @location = hash[:location]
+    @date = hash[:date]
+  end
+
+
+end

--- a/lib/open_mic.rb
+++ b/lib/open_mic.rb
@@ -7,5 +7,7 @@ class OpenMic
     @performers = []
   end
 
-
+  def welcome(comic)
+    @performers << comic
+  end
 end

--- a/test/open_mic_test.rb
+++ b/test/open_mic_test.rb
@@ -1,0 +1,24 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require '../lib/open_mic'
+require '../lib/user'
+require '../lib/joke'
+
+class OpenMicTest < Minitest::Test
+  def setup
+    @joke_1 = Joke.new(1, "Why did the strawberry cross the road?", "Because his mother was in a jam.")
+    @joke_2 = Joke.new(2, "How do you keep a lion from charging?", "Take away its credit cards.")
+    @sal = User.new("Sal")
+    @ali = User.new("Ali")
+    @open_mic = OpenMic.new({location: "Comedy Works", date: "11-20-19"})
+  end
+
+  def test_it_exists
+    assert_instance_of OpenMic, @open_mic
+  end
+
+  def test_it_has_argument_attributes
+    assert_equal "Comedy Works", @open_mic.location
+    assert_equal "11-20-19", @open_mic.date
+  end
+end

--- a/test/open_mic_test.rb
+++ b/test/open_mic_test.rb
@@ -21,4 +21,8 @@ class OpenMicTest < Minitest::Test
     assert_equal "Comedy Works", @open_mic.location
     assert_equal "11-20-19", @open_mic.date
   end
+
+  def test_it_starts_with_no_performers
+    assert_equal [], @open_mic.performers
+  end
 end

--- a/test/open_mic_test.rb
+++ b/test/open_mic_test.rb
@@ -25,4 +25,15 @@ class OpenMicTest < Minitest::Test
   def test_it_starts_with_no_performers
     assert_equal [], @open_mic.performers
   end
+
+  def test_it_can_welcome_new_performers
+    @open_mic.welcome(@sal)
+
+    assert_equal @sal, @open_mic.performers[0]
+
+    @open_mic.welcome(@ali)
+
+    assert_equal @ali, @open_mic.performers[1]
+    assert_equal 2, @open_mic.performers.length
+  end
 end


### PR DESCRIPTION
This PR adds the OpenMic class that will be used to organize an event for the Users and their Jokes.
The OpenMic class takes a Hash as an argument, with the Hash containing the `location` and `date` information. This is used in our `initialize` method to find the values associated with those keys and set them for future use.
The OpenMic also starts out with no `performers`, only returning an empty Array.
We have also implemented the `welcome` method for our OpenMic class, which allows the list of `performers` to grow with each added User.